### PR TITLE
added github actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -10,10 +10,7 @@ on:
 
 jobs:
  run:
-  permissions:
-    actions: read
-    contents: read
-  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@d08132e852a68b9e10b759cb30e23366219790b0
+  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
   with:
     artifact_name: 'dan-plugin-Nav' # Can be omitted, defaults to 'artifact'
     function_project_path: 'src/Dan.Plugin.Nav'

--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
  run:
+  permissions:
+    actions: read
+    contents: read
   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@e9a1d62778d9d2f4e8c2245027fb2750fd230e0a
   with:
     artifact_name: 'dan-plugin-Nav' # Can be omitted, defaults to 'artifact'

--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -13,7 +13,7 @@ jobs:
   permissions:
     actions: read
     contents: read
-  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@d08132e
+  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@d08132e852a68b9e10b759cb30e23366219790b0
   with:
     artifact_name: 'dan-plugin-Nav' # Can be omitted, defaults to 'artifact'
     function_project_path: 'src/Dan.Plugin.Nav'

--- a/.github/workflows/build-deploy-workflow.yml
+++ b/.github/workflows/build-deploy-workflow.yml
@@ -10,13 +10,16 @@ on:
 
 jobs:
  run:
-   uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@main
-   with:
-     artifact_name: 'dan-plugin-Nav' # Can be omitted, defaults to 'artifact'
-     function_project_path: 'src/Dan.Plugin.Nav'
-   secrets:
-     function_app_name: ${{ secrets.FUNCTIONAPP_NAME }}
-     publish_profile: ${{ secrets.AZURE_FUNCTION_PUBLISH_CREDS }}
-     azure_artifact_pat: ${{ secrets.AZURE_ARTIFACTS_PAT }}
-     azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-     resource_group_prod: ${{ secrets.RESOURCE_GROUP_PROD }}
+  permissions:
+    actions: read
+    contents: read
+  uses: data-altinn-no/deploy-actions/.github/workflows/dan-deploy-flow.yml@d08132e
+  with:
+    artifact_name: 'dan-plugin-Nav' # Can be omitted, defaults to 'artifact'
+    function_project_path: 'src/Dan.Plugin.Nav'
+  secrets:
+    function_app_name: ${{ secrets.FUNCTIONAPP_NAME }}
+    publish_profile: ${{ secrets.AZURE_FUNCTION_PUBLISH_CREDS }}
+    azure_artifact_pat: ${{ secrets.AZURE_ARTIFACTS_PAT }}
+    azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+    resource_group_prod: ${{ secrets.RESOURCE_GROUP_PROD }}


### PR DESCRIPTION
### Description
<!--- What and why -->
added github actions to dependabot, pinned version and added permissions to workflow
### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Enabled automated dependency updates to also cover GitHub Actions workflows, expanding routine update coverage.
* Added explicit, restricted permissions to CI/CD workflow jobs to reduce runtime privileges.
* Pinned external workflow references to fixed revisions to improve stability and predictability of deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->